### PR TITLE
Enforce style rules via EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+# Code files
+[*.cs,*.csx]
+indent_size = 4
+indent_style = space
+
+# Enforce documented coding style as warnings: /Documentation/coding-style.md
+# Suggestions inferred from existing code.
+[*.cs]
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_property = true:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = false:warning
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_properties = false:suggestion
+csharp_style_expression_bodied_indexers = false:suggestion
+csharp_style_expression_bodied_accessors = false:suggestion
+csharp_style_inlined_variable_declaration = false:suggestion

--- a/Documentation/coding-style.md
+++ b/Documentation/coding-style.md
@@ -28,7 +28,7 @@ The general rules:
 14. Fields should be specified at the top within type declarations.
 15. When including non-ASCII characters in the source code use Unicode escape sequences (\uXXXX) instead of literal characters. Literal non-ASCII characters occasionally get garbled by a tool or editor.
 
-We have provided a Visual Studio 2013 vssettings file (`stratis.fullnode.vssettings`) at the root of the full node repository, enabling C# auto-formatting conforming to the above guidelines.
+We have provided a Visual Studio 2017 EditorConfig file (`.editorconfig`) at the root of the full node repository, enabling C# auto-formatting and warnings conforming to some of the above guidelines.
 
 ### Example File:
 

--- a/Stratis.Bitcoin.FullNode.vs2017.sln
+++ b/Stratis.Bitcoin.FullNode.vs2017.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{5B331FD3-D493-46A9-928B-B786FC6F3103}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		global.json = global.json
 	EndProjectSection
 EndProject

--- a/Stratis.Bitcoin/RPC/Models/TransactionModel.cs
+++ b/Stratis.Bitcoin/RPC/Models/TransactionModel.cs
@@ -8,15 +8,17 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
+#pragma warning disable IDE1006 // Naming Styles (ignore lowercase)
 namespace Stratis.Bitcoin.RPC.Models
 {
+
     public abstract class TransactionModel
     {
         public TransactionModel(Network network = null) { }
 
         public TransactionModel(NBitcoin.Transaction trx)
         {
-            hex = trx?.ToHex();
+            this.hex = trx?.ToHex();
         }
 
         [JsonProperty(Order = 0)]
@@ -24,7 +26,7 @@ namespace Stratis.Bitcoin.RPC.Models
 
         public override string ToString()
         {
-            return hex;
+            return this.hex;
         }
     }
 
@@ -56,10 +58,10 @@ namespace Stratis.Bitcoin.RPC.Models
 
                 if (block != null)
                 {
-                    blockhash = block.HashBlock.ToString();
-                    time = blocktime = Utils.DateTimeToUnixTime(block.Header.BlockTime);
+                    this.blockhash = block.HashBlock.ToString();
+                    this.time = this.blocktime = Utils.DateTimeToUnixTime(block.Header.BlockTime);
                     if (tip != null)
-                        confirmations = tip.Height - block.Height + 1;
+                        this.confirmations = tip.Height - block.Height + 1;
                 }
             }
 
@@ -105,7 +107,7 @@ namespace Stratis.Bitcoin.RPC.Models
 
             if (prevOut.Hash == uint256.Zero)
             {
-                coinbase = Encoders.Hex.EncodeData(scriptSig.ToBytes());
+                this.coinbase = Encoders.Hex.EncodeData(scriptSig.ToBytes());
             }
             else
             {
@@ -117,7 +119,7 @@ namespace Stratis.Bitcoin.RPC.Models
 
         }
 
-        [JsonProperty(Order =0, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty(Order = 0, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string coinbase { get; set; }
 
         [JsonProperty(Order = 1, DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -161,8 +163,8 @@ namespace Stratis.Bitcoin.RPC.Models
 
         public Script(NBitcoin.Script script)
         {
-            asm = script.ToString();
-            hex = Encoders.Hex.EncodeData(script.ToBytes());
+            this.asm = script.ToString();
+            this.hex = Encoders.Hex.EncodeData(script.ToBytes());
         }
 
 
@@ -193,13 +195,13 @@ namespace Stratis.Bitcoin.RPC.Models
                 if (destinations.Count == 1)
                 {
                     this.reqSigs = 1;
-                    addresses = new List<string> { destinations[0].GetAddress(network).ToString() };
+                    this.addresses = new List<string> { destinations[0].GetAddress(network).ToString() };
                 }
                 else
                 {
-                    var multi = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(script);
+                    PayToMultiSigTemplateParameters multi = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(script);
                     this.reqSigs = multi.SignatureCount;
-                    addresses = multi.PubKeys.Select(m => m.GetAddress(network).ToString()).ToList();
+                    this.addresses = multi.PubKeys.Select(m => m.GetAddress(network).ToString()).ToList();
                 }
             }
         }
@@ -234,3 +236,4 @@ namespace Stratis.Bitcoin.RPC.Models
         }
     }
 }
+#pragma warning restore IDE1006 // Naming Styles


### PR DESCRIPTION
Enforce code-styles via .editorconfig (VS2017)

Add .editorconfig file to project root, enforcing Documentation/coding-style.md where explicit, and providing additional suggestions based on style of existing code.

Updates coding-sytle document to reflect this change and removes reference to stratis.fullnode.vssettings which does not exist in the repo.

Apply styles and suggestions to TransactionModel.cs